### PR TITLE
Fetching Twitter hashtags from meta keywords

### DIFF
--- a/src/jquery.socialshare.js
+++ b/src/jquery.socialshare.js
@@ -21,7 +21,7 @@
       image          : null,
       toWord         : true,
       twitterVia     : null,
-      twitterHashTags: null
+      twitterHashTags: $('meta[name=keywords]').attr("content")
     };
 
     var that = this;


### PR DESCRIPTION
This change enables the Twitter hashtags to be fetched from meta keywords directly.

Not a big deal, but instead of leaving the default as `null` this would be better I guess.

Thank you again for the great plugin!
